### PR TITLE
Fix tooltip scoping

### DIFF
--- a/src/chartkit.js
+++ b/src/chartkit.js
@@ -103,19 +103,29 @@
                     };
                   });
                 }
-                if (key === 'formatter' && value.template) {
-                  if (!obj.useHTML) {
-                    throw new Error('A formatter.template or formatter.templateUrl value must specify useHTML as true');
-                  }
-                  var template = value.template;
-                  var linkFn = $compile(template);
-                  obj.formatter = function() {
-                    return {
-                      linkFn: linkFn,
-                      scope: scope,
-                      data: this
+                if (key === 'formatter') {
+                  if (value.template) {
+                    if (!obj.useHTML) {
+                      throw new Error('A formatter.template or formatter.templateUrl value must specify useHTML as true');
+                    }
+                    var template = value.template;
+                    obj.tooltipLinkFn = $compile(template);
+                    obj.formatter = function chartkitFormatter() {
+                      return {
+                        linkFn: obj.tooltipLinkFn,
+                        scope: scope,
+                        data: this
+                      };
                     };
-                  };
+                  } else if (angular.isFunction(value) && value.name === 'chartkitFormatter') {
+                    obj.formatter = function chartkitFormatter() {
+                      return {
+                        linkFn: obj.tooltipLinkFn,
+                        scope: scope,
+                        data: this
+                      };
+                    };
+                  }
                 }
               });
               var chart = Highcharts.chart(element[0], chartSettings);

--- a/src/chartkit.js
+++ b/src/chartkit.js
@@ -110,22 +110,15 @@
                     }
                     var template = value.template;
                     obj.tooltipLinkFn = $compile(template);
-                    obj.formatter = function chartkitFormatter() {
-                      return {
-                        linkFn: obj.tooltipLinkFn,
-                        scope: scope,
-                        data: this
-                      };
-                    };
-                  } else if (angular.isFunction(value) && value.name === 'chartkitFormatter') {
-                    obj.formatter = function chartkitFormatter() {
-                      return {
-                        linkFn: obj.tooltipLinkFn,
-                        scope: scope,
-                        data: this
-                      };
-                    };
                   }
+                  
+                  obj.formatter = function() {
+                      return {
+                        linkFn: obj.tooltipLinkFn,
+                        scope: scope,
+                        data: this
+                      };
+                    };
                 }
               });
               var chart = Highcharts.chart(element[0], chartSettings);


### PR DESCRIPTION
This might be a crude fix, but when having multiple charts on the same page, the first chart created will share it's scope across all other charts, when showing a tooltip.

This pull request fixes that.
